### PR TITLE
#1255 implement get_icon_class() method to display correct icon in courseware

### DIFF
--- a/dmcloud/dmcloud.py
+++ b/dmcloud/dmcloud.py
@@ -103,6 +103,10 @@ class DmCloud(XBlock):
         self._cloudkey = None
         self._univ = None
 
+    def get_icon_class(self):
+        """Return the CSS class to be used in courseware sequence list."""
+        return 'video'
+
     @property
     def univ(self):
         """


### PR DESCRIPTION
en l'absence de la méthode `get_icon_class()` le xblock est identifié comme `other` affichant un mauvais icône dans le courseware.

https://fun.plan.io/issues/1255
